### PR TITLE
readme: Add note about org visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ jobs:
           steps.is_organization_member.outputs.result == false
         run: echo User Does Not Belong to testorg
 ```
+
+> **Note:** In order to check whether a member is part of the organization
+> or not, the members **must** have their "Organization Visibility" set to
+> Public.
+> In order to ensure your "Organization Visibility" is correct, please,
+> check https://github.com/orgs/**your_organization**/people.


### PR DESCRIPTION
By default members of an org are added with their "Organization
Visibility" set to Private, which will cause the action to return false,
as expected.  However, adding the note will save folks a lot of time as,
in case they consistently get wrong results, they at least have a hint
on what to check.

Fixes: #13

Signed-off-by: Fabiano Fidêncio <fabiano@fidencio.org>