### PR TITLE
Fix broken code in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Comment
         if: |
-          steps.is_organization_member.outputs.result == false
+          ${{ steps.is_organization_member.outputs.result == 'false' }}
         run: echo User Does Not Belong to testorg
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
       - name: Check if organization member
         id: is_organization_member
         if: github.event.action == 'opened'
-        uses: jamessingleton/is-organization-member@v1
+        uses: JamesSingleton/is-organization-member@1.0.0
         with:
           organization: testorg
           username: ${{ github.event.issue.user.login }}


### PR DESCRIPTION
The example workflow doesn't work as is because GitHub can't find the action:

```
Unable to resolve action `JamesSingleton/is-organization-member@v1`, unable to find version `v1`
```

I updated the version tag to `1.0.0` which has been working for me.

The condition in the `Create Comment` step wasn't working correctly because [github actions treats booleans as strings](https://github.com/actions/runner/issues/1483). `steps.is_organization_member.outputs.result == false` was false when the github user was not a part of the organization.

Thank you for creating this action!